### PR TITLE
fix(preprocess.py): compatible with `wikipedia` 20220301

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ try.py
 
 # Pyre type checker
 .pyre/
+
+# pretrain data
+examples/pretrain/pretrain_data/

--- a/examples/pretrain/preprocess.py
+++ b/examples/pretrain/preprocess.py
@@ -86,7 +86,7 @@ def create_wiki_data(tokenizer_name: str,
             if len(curr_block) > 0:
                 blocks.append(curr_block)
         
-        block = flat_list = list(itertools.chain(*blocks))
+        block = list(itertools.chain(*blocks))
         return {'token_ids': block}
 
     wiki = load_dataset("wikipedia", "20220301.en", split="train")

--- a/examples/pretrain/preprocess.py
+++ b/examples/pretrain/preprocess.py
@@ -97,8 +97,6 @@ def create_wiki_data(tokenizer_name: str,
     wiki = load_dataset("wikipedia", "20220301.simple", split="train")
     wiki = wiki.map(sentence_wiki, num_proc=8, remove_columns=["title", "text"])
     tokenized_wiki = wiki.map(wiki_tokenize_function, num_proc=64, batched=True, remove_columns=["sentences"])
-    # wiki_pad_each_line(tokenized_wiki)
-    # processed_wiki = tokenized_wiki.map(wiki_pad_each_line, num_proc=8, batched=True, remove_columns=["input_ids"], batch_size=32)
     processed_wiki = tokenized_wiki.map(wiki_pad_each_line, num_proc=64, remove_columns=["input_ids", "id", "url"], batched=False)
 
     return processed_wiki
@@ -156,8 +154,6 @@ if __name__ == '__main__':
         print('download and preprocess wiki and bookcorpus:')
         wiki = create_wiki_data(args.tokenizer_name, args.max_seq_length, args.short_seq_prob)
         book = create_book_data(args.tokenizer_name, args.max_seq_length, args.short_seq_prob)
-        import pdb
-        pdb.set_trace()
         dataset = concatenate_datasets([book, wiki])
         dataset.save_to_disk(args.output_dir)
     elif args.data == 'msmarco_passage':

--- a/examples/pretrain/preprocess.py
+++ b/examples/pretrain/preprocess.py
@@ -93,8 +93,8 @@ def create_wiki_data(tokenizer_name: str,
         block = flat_list = list(itertools.chain(*blocks))
         return {'token_ids': block}
 
-    # wiki = load_dataset("wikipedia", "20200501.en", split="train")
-    wiki = load_dataset("wikipedia", "20220301.simple", split="train")
+    wiki = load_dataset("wikipedia", "20200501.en", split="train")
+    # wiki = load_dataset("wikipedia", "20220301.simple", split="train")
     wiki = wiki.map(sentence_wiki, num_proc=8, remove_columns=["title", "text"])
     tokenized_wiki = wiki.map(wiki_tokenize_function, num_proc=64, batched=True, remove_columns=["sentences"])
     processed_wiki = tokenized_wiki.map(wiki_pad_each_line, num_proc=64, remove_columns=["input_ids", "id", "url"], batched=False)

--- a/examples/pretrain/preprocess.py
+++ b/examples/pretrain/preprocess.py
@@ -60,10 +60,6 @@ def create_wiki_data(tokenizer_name: str,
     tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
     target_length = max_seq_length - tokenizer.num_special_tokens_to_add(pair=False)
 
-
-    def row_to_batch(row):
-        return [row]
-
     def wiki_tokenize_function(examples):
         sentences = []
         for sents in examples['sentences']:

--- a/examples/pretrain/preprocess.py
+++ b/examples/pretrain/preprocess.py
@@ -93,7 +93,7 @@ def create_wiki_data(tokenizer_name: str,
         block = flat_list = list(itertools.chain(*blocks))
         return {'token_ids': block}
 
-    wiki = load_dataset("wikipedia", "20200501.en", split="train")
+    wiki = load_dataset("wikipedia", "20220301.en", split="train")
     # wiki = load_dataset("wikipedia", "20220301.simple", split="train")
     wiki = wiki.map(sentence_wiki, num_proc=8, remove_columns=["title", "text"])
     tokenized_wiki = wiki.map(wiki_tokenize_function, num_proc=64, batched=True, remove_columns=["sentences"])


### PR DESCRIPTION
以下全都是查 API 文档现修的，不一定对：

* 感觉是版本原因，我这边会 `Datasets.map` crash，没法很好的支持 `batched=True` 选项
* 支持 20220301 `wikipedia` 数据格式， https://huggingface.co/datasets/legacy-datasets/wikipedia
* 2024 年，训练机器好很多，改 64 核

修复后，我这边跑 simple 是正常的：
![image](https://github.com/staoxiao/RetroMAE/assets/7872421/1a6909cd-0e78-484c-9217-6b97fbf95842)
